### PR TITLE
updating state in priorities

### DIFF
--- a/src/PriorityNav.tsx
+++ b/src/PriorityNav.tsx
@@ -48,12 +48,12 @@ const Div = React.forwardRef<HTMLDivElement, DivElement>(
 function reducer(state: PriorityNavState, action: any) {
   switch (action.type) {
     case 'move':
-        const lastChild = state.children.reduceRight(child => child);
-        const newChildren = state.children.filter(child => child !== lastChild);
+      const lastChild = state.children.reduceRight(child => child);
+      const newChildren = state.children.filter(child => child !== lastChild);
       return {
         ...state,
         children: newChildren,
-        dropdownItems: [...lastChild].concat(state.dropdownItems),
+        dropdownItems:  [...state.dropdownItems, lastChild],
         ...(action.payload.lastItem && {
           lastItemWidth: [
             ...state.lastItemWidth,


### PR DESCRIPTION
 rearranging the order of the spread to fix the bug on resizing.
<img width="1618" alt="Screen Shot 2019-04-19 at 11 59 17 PM" src="https://user-images.githubusercontent.com/20182536/56453020-68bedf00-6300-11e9-8011-b85daf21732b.png">
<img width="1414" alt="Screen Shot 2019-04-20 at 12 00 28 AM" src="https://user-images.githubusercontent.com/20182536/56453021-6fe5ed00-6300-11e9-8de7-4575e91aa586.png">
